### PR TITLE
Added installing with setup.py in both docker and native

### DIFF
--- a/Dockerfile_archlinux
+++ b/Dockerfile_archlinux
@@ -21,7 +21,8 @@ RUN cd /seal-python/SEAL/native/src && \
     cmake . && \
     make && \
     make install && \
-    echo "/usr/local/lib" >> /etc/ld.so.conf.d/seal.conf
+    echo "/usr/local/lib" >> /etc/ld.so.conf.d/seal.conf && \
+    ldconfig
 
 # Install requirements of seal-python
 RUN cd /seal-python && \
@@ -45,3 +46,7 @@ RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # copy our files in
 COPY . /python-fhe
+
+# RUN cd / && \
+#     git clone -b master https://github.com/DreamingRaven/python-reseal && \
+#     mv python-reseal /python-fhe

--- a/Dockerfile_archlinux
+++ b/Dockerfile_archlinux
@@ -50,3 +50,6 @@ COPY . /python-fhe
 # RUN cd / && \
 #     git clone -b master https://github.com/DreamingRaven/python-reseal && \
 #     mv python-reseal /python-fhe
+
+RUN cd /python-fhe && \
+    python3 setup.py install

--- a/setup.py
+++ b/setup.py
@@ -111,13 +111,13 @@ packages = find_namespace_packages(
 print("namespace packages:", packages)
 
 setup(
-    name="pyrtd",
+    name="reseal",
     version=version,
     description="Template repository.",
     long_description=readme,
     long_description_content_type="text/markdown",
     author="George Onoufriou",
-    url="https://github.com/DreamingRaven/pyrtd",
+    url="https://github.com/DreamingRaven/python-reseal",
     packages=find_namespace_packages(),
     # scripts=['pyrtd'],
     install_requires=dependencies,


### PR DESCRIPTION
```from fhe.reseal import Reseal``` can  now be used once installed using standard methods of setup.py or inside docker container. 