### PR TITLE
Hexadecimal string instead of byte

### DIFF
--- a/fhe/reseal.py
+++ b/fhe/reseal.py
@@ -27,6 +27,7 @@ def _getstate_normal(self):
     with open(tf.name, "rb") as file:
         f = file.read()
     os.remove(tf.name)
+    f = f.hex()
     return {"file_contents": f}
 
 
@@ -34,7 +35,7 @@ def _setstate_normal(self, d):
     """Regenerate object state from serialised object."""
     tf = tempfile.NamedTemporaryFile(prefix="fhe_tmp_set_", delete=False)
     with open(tf.name, "wb") as f:
-        f.write(d["file_contents"])
+        f.write(bytes.fromhex(d["file_contents"]))
     if d.get("context"):
         self.load(d["context"], tf.name)
     else:

--- a/fhe/reseal.py
+++ b/fhe/reseal.py
@@ -130,6 +130,10 @@ class Reseal(object):
                  relin_keys=None,
                  galois_keys=None, cache=None):
         if scheme:
+            if scheme == 1:
+                scheme = seal.scheme_type.BFV
+            elif scheme == 2:
+                scheme = seal.scheme_type.CKKS
             self._scheme = scheme
         if poly_modulus_degree:
             self._poly_modulus_degree = poly_modulus_degree


### PR DESCRIPTION
The files saved by seal appear to be hexedecimal in nature, we can red the hexidecimal as hexidecimal instead of the byte contents of the file to theoretically save some space, and improve speed. All tests are passing, so will evaluate this over a longer period of time.

As a small aside I have also added integer handling for seal scheme types so the imported to python script does not also have to import seal.