### PR TITLE
Marshmallow validity testing ReScheme

### DIFF
--- a/fhe/reseal.py
+++ b/fhe/reseal.py
@@ -798,6 +798,7 @@ class Reseal_tests(unittest.TestCase):
     def test_validity(self):
         defaults = self.defaults_ckks()
         r = self.gen_reseal(defaults)
+        r.ciphertext = np.array([1, 2, 3])
         ReScheme().validate(r.__getstate__())
 
 

--- a/fhe/reseal.py
+++ b/fhe/reseal.py
@@ -10,6 +10,7 @@ import os
 import tempfile
 import unittest
 import numpy as np
+import marshmallow
 
 import seal
 
@@ -28,6 +29,7 @@ def _getstate_normal(self):
         f = file.read()
     os.remove(tf.name)
     f = f.hex()
+    # print(f[:32]) # print the first 32 characters of hexadecimal string
     return {"file_contents": f}
 
 
@@ -603,6 +605,24 @@ class ReCache():
         self._decryptor = decryptor
 
 
+class ReScheme(marshmallow.Schema):
+    _scheme = marshmallow.fields.Integer()
+    _poly_modulus_degree = marshmallow.fields.Integer()
+    _coefficient_modulus = marshmallow.fields.List(
+        marshmallow.fields.Integer())
+    _scale = marshmallow.fields.Float()
+    _parameters = marshmallow.fields.Dict(keys=marshmallow.fields.Str(),
+                                          values=marshmallow.fields.Str())
+    _public_key = marshmallow.fields.Dict(keys=marshmallow.fields.Str(),
+                                          values=marshmallow.fields.Str())
+    _private_key = marshmallow.fields.Dict(keys=marshmallow.fields.Str(),
+                                           values=marshmallow.fields.Str())
+    _relin_keys = marshmallow.fields.Dict(keys=marshmallow.fields.Str(),
+                                          values=marshmallow.fields.Str())
+    _ciphertext = marshmallow.fields.Dict(keys=marshmallow.fields.Str(),
+                                          values=marshmallow.fields.Str())
+
+
 class Reseal_tests(unittest.TestCase):
     """Unit test class aggregating all tests for the encryption class"""
 
@@ -774,6 +794,11 @@ class Reseal_tests(unittest.TestCase):
         defaults = self.defaults_ckks()
         r = self.gen_reseal(defaults)
         self.assertIsInstance(r.cache, ReCache)
+
+    def test_validity(self):
+        defaults = self.defaults_ckks()
+        r = self.gen_reseal(defaults)
+        ReScheme().validate(r.__getstate__())
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ConfigArgParse>=0.14.0
 numpy>=1.18.5
+marshmallow>=3.6.1


### PR DESCRIPTION
Marshmallow scheme has been included with reseal library for ease of validation, and to ensure the testing going on simultaneously to the main library, and adapted if it is out of date immediately, so others who use it can depend on it.