### PR TITLE
Math chaining by return of reseal object instead of ciphertext

### DIFF
--- a/fhe/reseal.py
+++ b/fhe/reseal.py
@@ -291,6 +291,15 @@ class Reseal(object):
             self.evaluator.rescale_to_next_inplace(encrypted_result)
         return encrypted_result
 
+    def __len__(self):
+        """Deduce the length of the encrypted vector from its poly mod deg."""
+        # depending on if BFV or CKKS we can deduce the number of slots
+        if self.scheme == seal.scheme_type.BFV:
+            return self.poly_modulus_degree
+        else:  # CKKS has half as many slots as the poly modulus degree
+            return self.poly_modulus_degree / 2
+        # TODO if this fails try using the encoder.slot_count()
+
     # reverse arithmetic operations
 
     def __radd__(self, other):

--- a/fhe/reseal.py
+++ b/fhe/reseal.py
@@ -234,6 +234,20 @@ class Reseal(object):
         # fall out the bottom again never to be seen again, so make sure
         # this is up to date.
 
+    def duplicate(self):
+        """Use state dict to instanciate a new ReSeal without ciphertext."""
+        # extract desired keys from out internal dictionary
+        d = self.__dict__
+        d = {k: d[k] for k, v in d.iteritems() if k not in ("_ciphertext",
+                                                            "_cache")}
+        print("NEW RESEAL DICT: {},\nORIGINAL RESEAL DICT: {}".format(
+            d,
+            self.__dict__))
+        # now override reseal object dict with new keys
+        new_reseal = Reseal()
+        for key in d:
+            new_reseal.__dict__[key] = d[key]
+
     def __str__(self):
         return str(self.__dict__)
 

--- a/fhe/reseal.py
+++ b/fhe/reseal.py
@@ -541,6 +541,9 @@ class Reseal(object):
     def ciphertext(self, data):
         if isinstance(data, seal.Ciphertext):
             self._ciphertext = data
+        elif isinstance(data, Reseal):
+            # compatibility so old setter "r.ciphertext = r + 2" still works
+            self.ciphertext = data.ciphertext
         else:
             plaintext = self._to_plaintext(data)
             ciphertext = seal.Ciphertext()


### PR DESCRIPTION
Please see the respective commits but in summary:

- __mult__ __add__ now properly return reseal objects instead of ciphertext to allow cycling/ chaining of addition and multiplication, as it should be.
- Tests have been updated to verify this functionality
- Added __len__ magic to get the size of the vector/ slot count
- Added duplicate function to generate a duplicate without ciphertext, so it can be set as new ciphertext
- Adapted setter ciphertext to check if ciphertext is a reseal or seal.ciphertext object, so we can handle both, allowing us to be backwards compatible with the old syntax such as r.ciphertext = r + 2 and new syntax r = r + 2